### PR TITLE
[MS-260] Updated navbar offset

### DIFF
--- a/src/part/navbar.tsx
+++ b/src/part/navbar.tsx
@@ -38,8 +38,8 @@ function NavigationBarLanguageDropdown() {
 
 
 export default function NavigationBar() {
-    return <nav className="ms-navbar navbar-expand-lg px-lg-5">
-        <div className="container-fluid">
+    return <nav className="ms-navbar navbar-expand-lg">
+        <div className="ms-s-offset my-0">
 
             <a className="navbar-brand" href={Locale.i18nLink("/")}>
                 <img src="/img/logo.64.webp" alt={_("ERROR.404_BTN")} className="d-inline-block align-text-top"

--- a/src/sass/navigation.scss
+++ b/src/sass/navigation.scss
@@ -8,11 +8,6 @@
   font-size: 1.6rem;
   height: $navbar-height-lg;
 
-  @media only screen and (min-width: ($ms-screen-lg)) {
-    margin-left: 10%;
-    margin-right: 10%;
-  }
-
   @media only screen and (max-width: ($ms-screen-lg - 1)) {
     // styles for the nav element when screen is small
     box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
- assigned .ms-s-offset class to navbar, to make sure it has the same width as all of the content through all breakpoints
- deleted excessive margins for lg screens