### PR TITLE
[MS 1225] change PurgeCSS safelist for CardImage molecule

### DIFF
--- a/webpack.com.js
+++ b/webpack.com.js
@@ -13,6 +13,7 @@ module.exports = {
         filename: "[name].[chunkhash:3].js",
         path: path.resolve(__dirname, "build"),
         publicPath: "/",
+        clean: true,
     },
     plugins: [
         // --------------- Static Content EN ---------------

--- a/webpack.prd.js
+++ b/webpack.prd.js
@@ -32,7 +32,15 @@ module.exports = merge(common, {
         new PurgeCSSPlugin({
             paths: glob.sync(`${PATHS.src}/**/*`, { nodir: true }),
             safelist: {
-                standard: [/active/, "navbar-collapse", /collapse/, "collapsing", /show/],
+                standard: [
+                    /active/,
+                    "navbar-collapse",
+                    /collapse/,
+                    "collapsing",
+                    /show/,
+                    /align-items-(start|center|end)/,
+                    /justify-content-(start|center|end)/,
+                ],
                 deep: [/^dropdown/, /^modal/, /^carousel/, /collapse/, /navbar/],
             },
         }),


### PR DESCRIPTION
- add bootstrap alignment classes to PurgeCSS plugin `safelist` for `CardImage` molecule:
    - `align-items-start`, `align-items-center`, `align-items-end`
    - `justify-content-start`, `justify-content-center`, `justify-content-end`
- add `clean` option to Webpack configuration to clean the `build` folder before each build