### PR TITLE
[MS-1224] correct font weight in CardTitleTextImage and CardTitleText molecules

### DIFF
--- a/src/atomic/molecule/card-title-text-image.tsx
+++ b/src/atomic/molecule/card-title-text-image.tsx
@@ -26,7 +26,7 @@ export default function CardTitleTextImage({
                 <h3 className="mb-3 pe-5 fs-4 lh-sm" style={{ color: textColor }}>
                     {title}
                 </h3>
-                <p className="mb-0 pe-4 fs-5 lh-sm" style={{ color: textColor }}>
+                <p className="mb-0 pe-5 fs-5 lh-sm" style={{ color: textColor }}>
                     {text}
                 </p>
             </div>

--- a/src/atomic/molecule/card-title-text-image.tsx
+++ b/src/atomic/molecule/card-title-text-image.tsx
@@ -1,6 +1,5 @@
 import React, { CSSProperties } from "react";
 import ImageI18N from "@/atomic/atom/img-i18n";
-import "@/sass/molecule/card-title-text-image.scss";
 
 interface CardTitleTextImageProps {
     title: string;
@@ -22,12 +21,12 @@ export default function CardTitleTextImage({
     textColor,
 }: CardTitleTextImageProps): React.ReactNode {
     return (
-        <div className="card-title-text-image d-flex flex-column h-100 rounded-5 shadow">
+        <div className="d-flex flex-column h-100 rounded-5 shadow">
             <div className="p-lg-5 p-4 mb-3">
-                <h3 className="title mb-3 pe-5 fs-4 lh-sm" style={{ color: textColor }}>
+                <h3 className="mb-3 pe-5 fs-4 lh-sm" style={{ color: textColor }}>
                     {title}
                 </h3>
-                <p className="text mb-0 pe-4 fs-5 lh-sm" style={{ color: textColor }}>
+                <p className="mb-0 pe-4 fs-5 lh-sm" style={{ color: textColor }}>
                     {text}
                 </p>
             </div>

--- a/src/atomic/molecule/card-title-text.tsx
+++ b/src/atomic/molecule/card-title-text.tsx
@@ -1,5 +1,4 @@
 import React, { CSSProperties } from "react";
-import "@/sass/molecule/card-title-text.scss";
 
 interface CardTitleTextProps {
     title: string;
@@ -10,11 +9,11 @@ interface CardTitleTextProps {
 
 export default function CardTitleText({ title, text, bgColor, textColor }: CardTitleTextProps): React.ReactNode {
     return (
-        <div className="card-title-text h-100 rounded-5 p-lg-5 p-4 pb-5" style={{ backgroundColor: bgColor }}>
-            <h3 className="title mb-3 pe-5 fs-4 lh-sm" style={{ color: textColor }}>
+        <div className="h-100 rounded-5 p-lg-5 p-4 pb-5" style={{ backgroundColor: bgColor }}>
+            <h3 className="mb-3 pe-5 fs-4 lh-sm" style={{ color: textColor }}>
                 {title}
             </h3>
-            <p className="text mb-0 pe-4 fs-5 lh-sm" style={{ color: textColor }}>
+            <p className="mb-0 pe-4 fs-5 lh-sm" style={{ color: textColor }}>
                 {text}
             </p>
         </div>

--- a/src/sass/molecule/card-title-text-image.scss
+++ b/src/sass/molecule/card-title-text-image.scss
@@ -1,9 +1,0 @@
-.card-title-text-image {
-    .title {
-        font-family: os5, sans-serif;
-    }
-
-    .text {
-        font-family: os4, sans-serif;
-    }
-}

--- a/src/sass/molecule/card-title-text.scss
+++ b/src/sass/molecule/card-title-text.scss
@@ -1,9 +1,0 @@
-.card-title-text {
-    .title {
-        font-family: os5, sans-serif;
-    }
-
-    .text {
-        font-family: os4, sans-serif;
-    }
-}


### PR DESCRIPTION
- correct font weight in `CardTitleTextImage` and `CardTitleText` molecules:
   - from `os4` to `os3` for text. 
     - `os4` sets font-weight to 400
     - `os3` sets font-weight to 300
   - `os3` is set for `<p>` on Vitamin page in `src\sass\page\base.scss`, class `ms-base-page`
   - `os5` is set for `<h3>` on Vitamin page in `src\sass\page\base-new.scss`, class `ms-base-new`
- correct text width with padding in `CardTitleTextImage` molecule to be more consistent with the design