### PR TITLE
[MS-1226] fix text transparency and weight in CardTitleSubtitle molecule

### DIFF
--- a/src/atomic/molecule/card-title-subtitle.tsx
+++ b/src/atomic/molecule/card-title-subtitle.tsx
@@ -42,7 +42,7 @@ export default function CardTitleSubtitle({
     subtitle,
     bgImg,
     titleColor = "#1686FF",
-    subtitleColor = "#151515",
+    subtitleColor = "#151515b3",
 }: CardTitleSubtitleProps): React.ReactNode {
     const bgImage = bgImg && { ...defaultBgSettings, ...bgImg };
 

--- a/src/sass/molecule/card-title-subtitle.scss
+++ b/src/sass/molecule/card-title-subtitle.scss
@@ -8,6 +8,7 @@
     }
 
     .subtitle {
+        font-family: os4, sans-serif;
         font-size: 1.25rem;
         max-width: 100%;
     }


### PR DESCRIPTION
- change the transparency of the subtitle color to 80% to match the design
- change the font-weight of the subtitle from 300 to 400