### PR TITLE
[MS-1224] fix font-weight and default text color in CardTitleTextImage and CardTitleText molecules

### DIFF
--- a/src/atomic/molecule/card-title-text-image.tsx
+++ b/src/atomic/molecule/card-title-text-image.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties } from "react";
 import ImageI18N from "@/atomic/atom/img-i18n";
+import "@/sass/molecule/card-title-text-image.scss";
 
 interface CardTitleTextImageProps {
     title: string;
@@ -8,6 +9,7 @@ interface CardTitleTextImageProps {
     imgH: number;
     imgW: number;
     imgAlt?: string;
+    titleColor?: CSSProperties["color"];
     textColor?: CSSProperties["color"];
 }
 
@@ -18,15 +20,16 @@ export default function CardTitleTextImage({
     imgH,
     imgW,
     imgAlt,
-    textColor,
+    titleColor = "#212529",
+    textColor = "#595959",
 }: CardTitleTextImageProps): React.ReactNode {
     return (
-        <div className="d-flex flex-column h-100 rounded-5 shadow">
+        <div className="card-title-text-image d-flex flex-column h-100 rounded-5 shadow">
             <div className="p-lg-5 p-4 mb-3">
-                <h3 className="mb-3 pe-5 fs-4 lh-sm" style={{ color: textColor }}>
+                <h3 className="mb-3 pe-5 fs-4 lh-sm" style={{ color: titleColor }}>
                     {title}
                 </h3>
-                <p className="mb-0 pe-5 fs-5 lh-sm" style={{ color: textColor }}>
+                <p className="text mb-0 pe-5 fs-5 lh-sm" style={{ color: textColor }}>
                     {text}
                 </p>
             </div>

--- a/src/atomic/molecule/card-title-text.tsx
+++ b/src/atomic/molecule/card-title-text.tsx
@@ -1,19 +1,27 @@
 import React, { CSSProperties } from "react";
+import "@/sass/molecule/card-title-text.scss";
 
 interface CardTitleTextProps {
     title: string;
     text: string;
     bgColor?: CSSProperties["color"];
+    titleColor?: CSSProperties["color"];
     textColor?: CSSProperties["color"];
 }
 
-export default function CardTitleText({ title, text, bgColor, textColor }: CardTitleTextProps): React.ReactNode {
+export default function CardTitleText({
+    title,
+    text,
+    bgColor,
+    titleColor = "#212529",
+    textColor = "#595959",
+}: CardTitleTextProps): React.ReactNode {
     return (
-        <div className="h-100 rounded-5 p-lg-5 p-4 pb-5" style={{ backgroundColor: bgColor }}>
-            <h3 className="mb-3 pe-5 fs-4 lh-sm" style={{ color: textColor }}>
+        <div className="card-title-text h-100 rounded-5 p-lg-5 p-4 pb-5" style={{ backgroundColor: bgColor }}>
+            <h3 className="mb-3 pe-5 fs-4 lh-sm" style={{ color: titleColor }}>
                 {title}
             </h3>
-            <p className="mb-0 pe-4 fs-5 lh-sm" style={{ color: textColor }}>
+            <p className="text mb-0 pe-4 fs-5 lh-sm" style={{ color: textColor }}>
                 {text}
             </p>
         </div>

--- a/src/atomic/page/vitamin.tsx
+++ b/src/atomic/page/vitamin.tsx
@@ -177,7 +177,6 @@ export default function Vitamin() {
                                 imgH={239}
                                 imgW={400}
                                 imgAlt={_("VITAMIN.ALT6")}
-                                textColor="#151515"
                             />
                         </div>
                         <div className="col p-0">
@@ -187,7 +186,6 @@ export default function Vitamin() {
                                         title={_("VITAMIN.LIST1.LI2_HEAD")}
                                         text={_("VITAMIN.LIST1.LI2_TEXT")}
                                         bgColor="#E5F4D9"
-                                        textColor="#151515"
                                     />
                                 </div>
                                 <div className="col py-0 mt-4">
@@ -195,7 +193,6 @@ export default function Vitamin() {
                                         title={_("VITAMIN.LIST1.LI3_HEAD")}
                                         text={_("VITAMIN.LIST1.LI3_TEXT")}
                                         bgColor="#E5EEFF"
-                                        textColor="#151515"
                                     />
                                 </div>
                             </div>

--- a/src/sass/molecule/card-title-text-image.scss
+++ b/src/sass/molecule/card-title-text-image.scss
@@ -1,0 +1,5 @@
+.card-title-text-image {
+    .text {
+        font-family: os4, sans-serif;
+    }
+}

--- a/src/sass/molecule/card-title-text.scss
+++ b/src/sass/molecule/card-title-text.scss
@@ -1,0 +1,5 @@
+.card-title-text {
+    .text {
+        font-family: os4, sans-serif;
+    }
+}


### PR DESCRIPTION
- add `titleColor` prop to `CardTitleTextImage` and `CardTitleText` molecules to set different colors for text and title
- change title color from `#151515` (new Vitamin page design) to `#212529` (current *title* color in other sections of Vitamin page)
- change text color from `#151515` (new Vitamin page design) to `#595959` (current *text* color in other sections of Vitamin page):
  - color `#595959` gives a more consistent display of text boldness in Chrome and Firefox
- return font-weight 400 (font-family `os4`) for text in `CardTitleTextImage` and `CardTitleText` molecules