### PR TITLE
[MS-1227] correct CardVitamin for link hover color, change colors of vitamins on vitamin page

### DIFF
--- a/src/atomic/molecule/card-vitamin.tsx
+++ b/src/atomic/molecule/card-vitamin.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from "react";
 import TextLinkArrow from "@/atomic/molecule/text-link-arrow";
-import "@/sass/molecule/card-vitamin.scss";
 import RightArrowIcon from "../atom/right-arrow-icon";
+import "@/sass/molecule/card-vitamin.scss";
 
 interface ActionLink {
     text: string;

--- a/src/atomic/molecule/card-vitamin.tsx
+++ b/src/atomic/molecule/card-vitamin.tsx
@@ -22,7 +22,7 @@ interface CardVitaminProps {
     bgImg: BackgroundImage;
     bgColor: CSSProperties["color"];
     primaryColor: CSSProperties["color"];
-    linkColor: CSSProperties["color"];
+    linkHoverColor: CSSProperties["color"];
 }
 
 export default function CardVitamin({
@@ -33,7 +33,7 @@ export default function CardVitamin({
     bgImg,
     bgColor,
     primaryColor,
-    linkColor,
+    linkHoverColor,
 }: CardVitaminProps): React.ReactNode {
     const subtitleColor: CSSProperties["color"] = "#151515b3";
     const descriptionColor: CSSProperties["color"] = "#15151599";
@@ -72,8 +72,8 @@ export default function CardVitamin({
                 <TextLinkArrow
                     rightIcon={<RightArrowIcon />}
                     {...actionLink}
-                    color={linkColor}
-                    hoverColor={primaryColor}
+                    color={primaryColor}
+                    hoverColor={linkHoverColor}
                 />
             </div>
             {bgImg && (

--- a/src/atomic/page/vitamin.tsx
+++ b/src/atomic/page/vitamin.tsx
@@ -21,7 +21,7 @@ interface VitaminGroup {
     bgImg: VitaminCard.BackgroundImage;
     bgColor: React.CSSProperties["color"];
     primaryColor: React.CSSProperties["color"];
-    linkColor: React.CSSProperties["color"];
+    linkHoverColor: React.CSSProperties["color"];
     itemList: string[];
 }
 
@@ -30,16 +30,16 @@ const vitamins: VitaminGroup[] = [
         groupName: "VITAMIN_FAT",
         bgImg: { src: "/img/page/vitamin/vitamin-card-fat-soluble-bg.svg", width: 128, height: 92 },
         bgColor: "#fff3e9",
-        primaryColor: "#c04c05",
-        linkColor: "#b05905",
+        primaryColor: "#e95813",
+        linkHoverColor: "#ff8f32",
         itemList: ["VITAMIN_A", "VITAMIN_D", "VITAMIN_E", "VITAMIN_K"],
     },
     {
         groupName: "VITAMIN_WATER",
         bgImg: { src: "/img/page/vitamin/vitamin-card-water-soluble-bg.svg", width: 124, height: 121 },
         bgColor: "#eaf1fd",
-        primaryColor: "#0866eb",
-        linkColor: "#2563c8",
+        primaryColor: "#0f75dc",
+        linkHoverColor: "#399cff",
         itemList: [
             "VITAMIN_B1",
             "VITAMIN_B2",
@@ -56,8 +56,8 @@ const vitamins: VitaminGroup[] = [
         groupName: "MINERAL",
         bgImg: { src: "/img/page/vitamin/vitamin-card-minerals-bg.svg", width: 129, height: 118 },
         bgColor: "#e5f4d9",
-        primaryColor: "#307d02",
-        linkColor: "#406c30",
+        primaryColor: "#388205",
+        linkHoverColor: "#73c631",
         itemList: [
             "CALCIUM",
             "CHLORIDE",
@@ -336,7 +336,7 @@ export default function Vitamin() {
                         </div>
                     </div>
 
-                    {vitamins.map(({ groupName, bgImg, bgColor, primaryColor, linkColor, itemList }) => (
+                    {vitamins.map(({ groupName, bgImg, bgColor, primaryColor, linkHoverColor, itemList }) => (
                         <section key={`vitamins-group-${groupName}`} className="row mt-5 pt-4 mb-0">
                             <div className="col-12 mb-5">
                                 <h3
@@ -359,7 +359,7 @@ export default function Vitamin() {
                                             }}
                                             bgColor={bgColor}
                                             primaryColor={primaryColor}
-                                            linkColor={linkColor}
+                                            linkHoverColor={linkHoverColor}
                                             bgImg={bgImg}
                                         />
                                     </li>


### PR DESCRIPTION
- change `CardVitamin` to get a hover color for the link and use the primary color as the base color for the link
- change color of vitamins on the Vitamin page:
  - **fat-soluble vitamins**:
    - vitamin and link color (primary color): `#E95813`
    - link hover color: `#FF8F32`
  - **water-soluble vitamins**:
    - vitamin and link color (primary color): `#0F75DC`
    - link hover color: `#399CFF`
  - **minerals**:
    - vitamin and link color (primary color): `#388205`
    - link hover color: `#73C631`