### PR TITLE
[MS-1318] Ladle: add CardImage story

### DIFF
--- a/src/stories/molecule/card-image.stories.tsx
+++ b/src/stories/molecule/card-image.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import type { Story, StoryDefault } from "@ladle/react";
+import CardImage from "@/atomic/molecule/card-image";
+import _, { Locale } from "@/i18n/locale";
+
+export default {
+    title: "Molecule",
+} satisfies StoryDefault;
+
+export const CardImageStory: Story = () => {
+
+    const currentLanguage = Locale.language;
+    const imgSrc = `/img/page/vitamin/vitamin-watches-${currentLanguage}.webp`;
+
+    return (
+        <div className="col col-md-12 row-cols-xl-3 d-flex justify-content-center align-items-center">
+            <CardImage
+                imgSrc={imgSrc}
+                imgH={720}
+                imgW={664}
+                imgAlt={_("VITAMIN.ALT4")}
+                bgColor={"#F2F2F5"}
+            />
+        </div>
+    );
+}
+
+CardImageStory.storyName = "CardImage";


### PR DESCRIPTION
Добавлена Ladle story для компонента CardImage (уровень - Молекула) с поддержкой динамической подстановки языка в пути к изображению.
![image](https://github.com/user-attachments/assets/67dcf0c6-7d51-4046-9393-13852f64a7ef)
