### PR TITLE
[MS-1325] Ladle: add CardTitleTextButton story

### DIFF
--- a/src/stories/molecule/card-title-text-button.stories.tsx
+++ b/src/stories/molecule/card-title-text-button.stories.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import type { Story, StoryDefault } from "@ladle/react";
+import CardTitleTextButton from "@/atomic/molecule/card-title-text-button";
+import _, { Locale } from "@/i18n/locale";
+
+export default {
+    title: "Molecule",
+} satisfies StoryDefault;
+
+export const CardTitleTextButtonStory: Story = () => (
+    <div className="row" style={{maxWidth: "1060px"}}>
+        <CardTitleTextButton
+            title={_("ELECTROLYTE.HEAD2")}
+            textContent={[_("ELECTROLYTE.DESC2_1"), _("ELECTROLYTE.DESC2_2")]}
+            buttonText={_("ELECTROLYTE.BTN_MORE")}
+            buttonLink={Locale.i18nLink(`coming-soon`)}
+            buttonColor={"#8079CC"}
+        />
+    </div>
+);
+
+CardTitleTextButtonStory.storyName = "CardTitleTextButton";


### PR DESCRIPTION
Добавлена Ladle story для компонента CardTitleTextButton, уровень - Молекула.
![image](https://github.com/user-attachments/assets/cda69ca0-8711-452e-9335-b17f14d40cf1)
