### PR TITLE
[MS-1327] Ladle: add CardTitleText story

### DIFF
--- a/src/stories/molecule/card-title-text.stories.tsx
+++ b/src/stories/molecule/card-title-text.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import type { Story, StoryDefault } from "@ladle/react";
+import CardTitleText from "@/atomic/molecule/card-title-text";
+import _, { Locale } from "@/i18n/locale";
+
+export default {
+    title: "Molecule",
+} satisfies StoryDefault;
+
+export const CardTitleTextStory: Story = () => (
+    <div style={{maxWidth: "385px"}}>
+        <CardTitleText
+            title={_("VITAMIN.LIST1.LI3_HEAD")}
+            text={_("VITAMIN.LIST1.LI3_TEXT")}
+            bgColor="#E5EEFF"
+        />
+    </div>
+);
+
+CardTitleTextStory.storyName = "CardTitleText";


### PR DESCRIPTION
Добавлена Ladle story для компонента CardTitleText, уровень - Молекула.
![image](https://github.com/user-attachments/assets/bf245460-de37-45f6-bd72-e464c7897699)
