### PR TITLE
feat: add Ladle story for Contents List component

### DIFF
--- a/src/stories/molecule/contents-list.stories.tsx
+++ b/src/stories/molecule/contents-list.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import type { Story, StoryDefault } from "@ladle/react";
+
+import ContentsList from "@/atomic/molecule/contents-list";
+
+export default {
+    title: "Molecule",
+} satisfies StoryDefault;
+
+export const ContentsListStory: Story = () => (
+    <section className="personality-trait d-flex justify-content-center">
+        <div className="contents-list">
+            <ContentsList PAGE="ANXIETY" CONTENTS_COUNT={5} />
+        </div>
+    </section>
+);
+
+ContentsListStory.storyName = "ContentsList";


### PR DESCRIPTION
<img width="594" alt="Screenshot 2024-11-10 at 20 49 41" src="https://github.com/user-attachments/assets/ade5c7c8-d905-4dba-8963-1301b032efc7">

Добавлена story для компонента Contents List (уровень молекула). Дополнительные "обертки" (div, section) необходимы для сохранения стилей, шрифтов и центрирования.