### PR TITLE
[Ms 1329] Ladle: add Icon Wrapper decorator

### DIFF
--- a/.ladle/decorators.tsx
+++ b/.ladle/decorators.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Story } from "@ladle/react";
+
+export const IconWrapper = (Component: Story) => (
+    <div
+        className="d-flex justify-content-center mx-auto p-4 overflow-hidden border-0 rounded-4"
+        style={{ backgroundColor: "#f4f4f4", minWidth: "100px" }}
+    >
+        <Component />
+    </div>
+);

--- a/src/stories/atom/button-apple.stories.tsx
+++ b/src/stories/atom/button-apple.stories.tsx
@@ -1,18 +1,14 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 import appIds from "@/data/app-ids.json";
-
 import ButtonApple from "@/atomic/atom/button-apple";
+import { IconWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
 } satisfies StoryDefault;
 
-export const ButtonAppleStory: Story = () => (
-    <ButtonApple
-        appId={appIds["vitamin"]}
-        appDownloadTitle={'Vitamin'}
-    />
-);
+export const ButtonAppleStory: Story = () => <ButtonApple appId={appIds["vitamin"]} appDownloadTitle={"Vitamin"} />;
 
+ButtonAppleStory.decorators = [IconWrapper];
 ButtonAppleStory.storyName = "ButtonApple";

--- a/src/stories/atom/icon-chevron-circle.stories.tsx
+++ b/src/stories/atom/icon-chevron-circle.stories.tsx
@@ -1,19 +1,17 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 import IconChevronCircle from "@/atomic/atom/icon-chevron-circle";
+import { IconWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
 } satisfies StoryDefault;
 
 export const IconChevronCircleStory: Story = () => (
-    <div 
-        className="accordion-header d-flex justify-content-center mx-auto p-4 overflow-hidden border-0 rounded-4" 
-        style={{ backgroundColor: "rgb(255, 243, 233)", maxWidth: "100px"}}
-    >
+    <div>
         <IconChevronCircle />
     </div>
-    
 );
 
+IconChevronCircleStory.decorators = [IconWrapper];
 IconChevronCircleStory.storyName = "IconChevronCircle";

--- a/src/stories/atom/icon-with-load.stories.tsx
+++ b/src/stories/atom/icon-with-load.stories.tsx
@@ -1,25 +1,25 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 import IconWithLoad from "@/atomic/atom/icon-with-load";
+import { IconWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
 } satisfies StoryDefault;
 
 export const IconWithLoadStory: Story<{
-		classActive: string;
-		classPassive: string;
-		isActive: boolean;
-		isLoading: boolean;
-}> = (props) => (
-		<IconWithLoad {...props} />
-);
+    classActive: string;
+    classPassive: string;
+    isActive: boolean;
+    isLoading: boolean;
+}> = (props) => <IconWithLoad {...props} />;
 
 IconWithLoadStory.args = {
-		classActive: "active",
-		classPassive: "passive",
-		isActive: true,
-		isLoading: true
+    classActive: "active",
+    classPassive: "passive",
+    isActive: true,
+    isLoading: true,
 };
 
+IconWithLoadStory.decorators = [IconWrapper];
 IconWithLoadStory.storyName = "IconWithLoad";

--- a/src/stories/atom/right-arrow-icon.stories.tsx
+++ b/src/stories/atom/right-arrow-icon.stories.tsx
@@ -1,21 +1,21 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 import RightArrowIcon from "@/atomic/atom/right-arrow-icon";
+import { IconWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
 } satisfies StoryDefault;
 
 export const RightArrowIconStory: Story<{
-		items: object;
-}> = (props) => (
-		<RightArrowIcon {...props.items} />
-);
+    items: object;
+}> = (props) => <RightArrowIcon {...props.items} />;
 
 RightArrowIconStory.args = {
-		items: {
-				style: {color: "#999"}
-		}
+    items: {
+        style: { color: "#999" },
+    },
 };
 
+RightArrowIconStory.decorators = [IconWrapper];
 RightArrowIconStory.storyName = "RightArrowIcon";

--- a/src/stories/atom/star-icon.stories.tsx
+++ b/src/stories/atom/star-icon.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 
 import StarIcon from "@/atomic/atom/star-icon";
+import { IconWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -9,4 +10,5 @@ export default {
 
 export const StarIconStory: Story = () => <StarIcon />;
 
+StarIconStory.decorators = [IconWrapper];
 StarIconStory.storyName = "StarIcon";


### PR DESCRIPTION
Реализована обертка для иконок и кнопок. В качестве фона выбран светло-серый цвет, совпадающий с цветом правой панели Ladle. Он одновременно служит универсальной подложкой (на нем видны как светлые, так и темные элементы), и в то же время, благодаря совпадению с интерфейсом Ladle, не воспринимается как часть компонента.