### PR TITLE
[MS-1341] Ladle: add TitleTextCard story

### DIFF
--- a/src/stories/molecule/title-text-card.stories.tsx
+++ b/src/stories/molecule/title-text-card.stories.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import type { Story, StoryDefault } from "@ladle/react";
+import TitleTextCard from "@/atomic/molecule/title-text-card";
+import _, { Locale } from "@/i18n/locale";
+
+export default {
+    title: "Molecule",
+} satisfies StoryDefault;
+
+export const TitleTextCardStory: Story = () => (
+    <div style={{ maxWidth: "793px" }}>
+        <TitleTextCard
+            title={_("EMOTION.LIST1.LI1_HEAD")}
+            text={_("EMOTION.LIST1.LI1_TEXT")}
+            bgColor="#EDE1FF"
+            className="col-lg-8 col-md-6 w-100"
+        />
+    </div>
+);
+
+TitleTextCardStory.storyName = "TitleTextCard";


### PR DESCRIPTION
Добавлена Ladle story для компонента TitleTextCard, уровень - Молекула.
![image](https://github.com/user-attachments/assets/7827d5c7-65e3-4040-aae2-a77a82a30252)
