### PR TITLE
[MS-1364] Ladle: add PageWrapper decorator to all stories

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -11,7 +11,7 @@ Locale.init();
 
 // share locale and styles via decorator
 export const Provider: GlobalProvider = ({ children }) => (
-    <article className="ms-base-page ms-base-new h-100 d-flex justify-content-center align-items-center">
+    <>
         {children}
-    </article>
+    </>
 );

--- a/src/stories/atom/button-apple.stories.tsx
+++ b/src/stories/atom/button-apple.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 import appIds from "@/data/app-ids.json";
+
 import ButtonApple from "@/atomic/atom/button-apple";
-import { IconWrapper } from ".ladle/decorators";
+import { IconWrapper, PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -10,5 +11,5 @@ export default {
 
 export const ButtonAppleStory: Story = () => <ButtonApple appId={appIds["vitamin"]} appDownloadTitle={"Vitamin"} />;
 
-ButtonAppleStory.decorators = [IconWrapper];
+ButtonAppleStory.decorators = [IconWrapper, PageWrapper];
 ButtonAppleStory.storyName = "ButtonApple";

--- a/src/stories/atom/icon-chevron-circle.stories.tsx
+++ b/src/stories/atom/icon-chevron-circle.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+
 import IconChevronCircle from "@/atomic/atom/icon-chevron-circle";
-import { IconWrapper } from ".ladle/decorators";
+import { IconWrapper, PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -13,5 +14,5 @@ export const IconChevronCircleStory: Story = () => (
     </div>
 );
 
-IconChevronCircleStory.decorators = [IconWrapper];
+IconChevronCircleStory.decorators = [IconWrapper, PageWrapper];
 IconChevronCircleStory.storyName = "IconChevronCircle";

--- a/src/stories/atom/icon-with-load.stories.tsx
+++ b/src/stories/atom/icon-with-load.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+
 import IconWithLoad from "@/atomic/atom/icon-with-load";
-import { IconWrapper } from ".ladle/decorators";
+import { IconWrapper, PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -21,5 +22,5 @@ IconWithLoadStory.args = {
     isLoading: true,
 };
 
-IconWithLoadStory.decorators = [IconWrapper];
+IconWithLoadStory.decorators = [IconWrapper, PageWrapper];
 IconWithLoadStory.storyName = "IconWithLoad";

--- a/src/stories/atom/img-i18n.stories.tsx
+++ b/src/stories/atom/img-i18n.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+
 import ImageI18N from "@/atomic/atom/img-i18n";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -22,4 +24,5 @@ ImageI18NStory.args = {
     w: 512,
 };
 
+ImageI18NStory.decorators = [PageWrapper];
 ImageI18NStory.storyName = "ImageI18N";

--- a/src/stories/atom/link-styled-button.stories.tsx
+++ b/src/stories/atom/link-styled-button.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import _, { Locale } from "@/i18n/locale";
 import type { Story, StoryDefault } from "@ladle/react";
+
 import LinkStyledButton from "@/atomic/atom/link-styled-button";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -25,4 +27,5 @@ LinkStyledButtonStory.args = {
     className: "btn",
 };
 
+LinkStyledButtonStory.decorators = [PageWrapper];
 LinkStyledButtonStory.storyName = "LinkStyledButton";

--- a/src/stories/atom/right-arrow-icon.stories.tsx
+++ b/src/stories/atom/right-arrow-icon.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+
 import RightArrowIcon from "@/atomic/atom/right-arrow-icon";
-import { IconWrapper } from ".ladle/decorators";
+import { IconWrapper, PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -17,5 +18,5 @@ RightArrowIconStory.args = {
     },
 };
 
-RightArrowIconStory.decorators = [IconWrapper];
+RightArrowIconStory.decorators = [IconWrapper, PageWrapper];
 RightArrowIconStory.storyName = "RightArrowIcon";

--- a/src/stories/atom/star-icon.stories.tsx
+++ b/src/stories/atom/star-icon.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 
 import StarIcon from "@/atomic/atom/star-icon";
-import { IconWrapper } from ".ladle/decorators";
+import { IconWrapper, PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Atom",
@@ -10,5 +10,5 @@ export default {
 
 export const StarIconStory: Story = () => <StarIcon />;
 
-StarIconStory.decorators = [IconWrapper];
+StarIconStory.decorators = [IconWrapper, PageWrapper];
 StarIconStory.storyName = "StarIcon";

--- a/src/stories/molecule/accordion.stories.tsx
+++ b/src/stories/molecule/accordion.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import Accordion from "@/atomic/molecule/accordion";
 import _ from "@/i18n/locale";
+
+import Accordion from "@/atomic/molecule/accordion";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -22,4 +24,5 @@ export const AccordionStory: Story = () => (
     </section>
 );
 
+AccordionStory.decorators = [PageWrapper];
 AccordionStory.storyName = "Accordion";

--- a/src/stories/molecule/bullet-list.stories.tsx
+++ b/src/stories/molecule/bullet-list.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import BulletList from "@/atomic/molecule/bullet-list";
 import _ from "@/i18n/locale";
+
+import BulletList from "@/atomic/molecule/bullet-list";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -32,4 +34,5 @@ BulletListStory.args = {
     className: "bullet-list",
 };
 
+BulletListStory.decorators = [PageWrapper];
 BulletListStory.storyName = "BulletList";

--- a/src/stories/molecule/card-image.stories.tsx
+++ b/src/stories/molecule/card-image.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import CardImage from "@/atomic/molecule/card-image";
 import _, { Locale } from "@/i18n/locale";
+
+import CardImage from "@/atomic/molecule/card-image";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -25,4 +27,5 @@ export const CardImageStory: Story = () => {
     );
 }
 
+CardImageStory.decorators = [PageWrapper];
 CardImageStory.storyName = "CardImage";

--- a/src/stories/molecule/card-title-subtitle.stories.tsx
+++ b/src/stories/molecule/card-title-subtitle.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import CardTitleSubtitle, { CardTitleSubtitleProps } from "@/atomic/molecule/card-title-subtitle";
 import _ from "@/i18n/locale";
+
+import CardTitleSubtitle, { CardTitleSubtitleProps } from "@/atomic/molecule/card-title-subtitle";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -32,4 +34,5 @@ CardTitleSubtitleStory.args = {
     },
 };
 
+CardTitleSubtitleStory.decorators = [PageWrapper];
 CardTitleSubtitleStory.storyName = "CardTitleSubtitle";

--- a/src/stories/molecule/card-title-text-button.stories.tsx
+++ b/src/stories/molecule/card-title-text-button.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import CardTitleTextButton from "@/atomic/molecule/card-title-text-button";
 import _, { Locale } from "@/i18n/locale";
+
+import CardTitleTextButton from "@/atomic/molecule/card-title-text-button";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -18,5 +20,5 @@ export const CardTitleTextButtonStory: Story = () => (
         />
     </div>
 );
-
+CardTitleTextButtonStory.decorators = [PageWrapper];
 CardTitleTextButtonStory.storyName = "CardTitleTextButton";

--- a/src/stories/molecule/card-title-text-image.stories.tsx
+++ b/src/stories/molecule/card-title-text-image.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+import _ from "@/i18n/locale";
+
 import CardTitleTextImage from "@/atomic/molecule/card-title-text-image";
-import _, { Locale } from "@/i18n/locale";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -20,4 +22,5 @@ export const CardTitleTextImageStory: Story = () => (
     </div>
 );
 
+CardTitleTextImageStory.decorators = [PageWrapper];
 CardTitleTextImageStory.storyName = "CardTitleTextImage";

--- a/src/stories/molecule/card-title-text.stories.tsx
+++ b/src/stories/molecule/card-title-text.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+import _ from "@/i18n/locale";
+
 import CardTitleText from "@/atomic/molecule/card-title-text";
-import _, { Locale } from "@/i18n/locale";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -17,4 +19,5 @@ export const CardTitleTextStory: Story = () => (
     </div>
 );
 
+CardTitleTextStory.decorators = [PageWrapper];
 CardTitleTextStory.storyName = "CardTitleText";

--- a/src/stories/molecule/card-vitamin.stories.tsx
+++ b/src/stories/molecule/card-vitamin.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import CardVitamin from "@/atomic/molecule/card-vitamin";
 import _, { Locale } from "@/i18n/locale";
+
+import CardVitamin from "@/atomic/molecule/card-vitamin";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -25,4 +27,5 @@ export const CardVitaminStory: Story = () => (
     </div>
 );
 
+CardVitaminStory.decorators = [PageWrapper];
 CardVitaminStory.storyName = "CardVitamin";

--- a/src/stories/molecule/contents-list.stories.tsx
+++ b/src/stories/molecule/contents-list.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 
 import ContentsList from "@/atomic/molecule/contents-list";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -15,4 +16,5 @@ export const ContentsListStory: Story = () => (
     </section>
 );
 
+ContentsListStory.decorators = [PageWrapper];
 ContentsListStory.storyName = "ContentsList";

--- a/src/stories/molecule/icon-title-text-elem.stories.tsx
+++ b/src/stories/molecule/icon-title-text-elem.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+import _ from "@/i18n/locale";
+
 import IconTitleTextElem from "@/atomic/molecule/icon-title-text-elem";
-import _, { Locale } from "@/i18n/locale";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -20,4 +22,5 @@ export const IconTitleTextElemStory: Story = () => (
     </div>
 );
 
+IconTitleTextElemStory.decorators = [PageWrapper];
 IconTitleTextElemStory.storyName = "IconTitleTextElem";

--- a/src/stories/molecule/page-header.stories.tsx
+++ b/src/stories/molecule/page-header.stories.tsx
@@ -3,6 +3,7 @@ import type { Story, StoryDefault } from "@ladle/react";
 import _ from "@/i18n/locale";
 
 import PageHeader from "@/atomic/molecule/page-header";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -23,4 +24,5 @@ export const PageHeaderStory: Story = () => (
     </div>
 );
 
+PageHeaderStory.decorators = [PageWrapper];
 PageHeaderStory.storyName = "PageHeader";

--- a/src/stories/molecule/review-card.stories.tsx
+++ b/src/stories/molecule/review-card.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import ReviewCard from "@/atomic/molecule/review-card";
 import _ from "@/i18n/locale";
+
+import ReviewCard from "@/atomic/molecule/review-card";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -21,4 +23,5 @@ export const ReviewCardStory: Story = () => (
     </div>
 );
 
+ReviewCardStory.decorators = [PageWrapper];
 ReviewCardStory.storyName = "ReviewCard";

--- a/src/stories/molecule/review-description.stories.tsx
+++ b/src/stories/molecule/review-description.stories.tsx
@@ -5,6 +5,7 @@ import appIds from "@/data/app-ids.json";
 
 import ReviewDescription from "@/atomic/molecule/review-description";
 import { ReviewContext } from "@/atomic/molecule/review-context";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -35,4 +36,5 @@ export const ReviewDescriptionStory: Story = () => (
     </ReviewContext.Provider>
 );
 
+ReviewDescriptionStory.decorators = [PageWrapper];
 ReviewDescriptionStory.storyName = "ReviewDescription";

--- a/src/stories/molecule/review-filler-card.stories.tsx
+++ b/src/stories/molecule/review-filler-card.stories.tsx
@@ -6,6 +6,7 @@ import appIds from "@/data/app-ids.json";
 import ReviewFillerCard from "@/atomic/molecule/review-filler-card";
 import { ReviewContext } from "@/atomic/molecule/review-context";
 import { SendReviewsLink } from "@/atomic/organism/review-link";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -38,4 +39,5 @@ export const ReviewFillerCardStory: Story = () => (
     </ReviewContext.Provider>
 );
 
+ReviewFillerCardStory.decorators = [PageWrapper];
 ReviewFillerCardStory.storyName = "ReviewFillerCard";

--- a/src/stories/molecule/review-head.stories.tsx
+++ b/src/stories/molecule/review-head.stories.tsx
@@ -5,6 +5,7 @@ import appIds from "@/data/app-ids.json";
 
 import ReviewHead from "@/atomic/molecule/review-head";
 import { ReviewContext } from "@/atomic/molecule/review-context";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -33,4 +34,5 @@ export const ReviewHeadStory: Story = () => (
     </ReviewContext.Provider>
 );
 
+ReviewHeadStory.decorators = [PageWrapper];
 ReviewHeadStory.storyName = "ReviewHead";

--- a/src/stories/molecule/team-member.stories.tsx
+++ b/src/stories/molecule/team-member.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 
 import TeamMember from "@/atomic/molecule/team-Member";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -23,4 +24,5 @@ export const TeamMemberStory: Story = () => (
     </div>
 );
 
+TeamMemberStory.decorators = [PageWrapper];
 TeamMemberStory.storyName = "TeamMember";

--- a/src/stories/molecule/text-link-arrow.stories.tsx
+++ b/src/stories/molecule/text-link-arrow.stories.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+import _, { Locale } from "@/i18n/locale";
+
 import TextLinkArrow from "@/atomic/molecule/text-link-arrow";
 import RightArrowIcon from "@/atomic/atom/right-arrow-icon";
-import _, { Locale } from "@/i18n/locale";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -19,4 +21,5 @@ export const TextLinkArrowStory: Story = () => (
     />
 );
 
+TextLinkArrowStory.decorators = [PageWrapper];
 TextLinkArrowStory.storyName = "TextLinkArrow";

--- a/src/stories/molecule/title-text-card.stories.tsx
+++ b/src/stories/molecule/title-text-card.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+import _ from "@/i18n/locale";
+
 import TitleTextCard from "@/atomic/molecule/title-text-card";
-import _, { Locale } from "@/i18n/locale";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -18,4 +20,5 @@ export const TitleTextCardStory: Story = () => (
     </div>
 );
 
+TitleTextCardStory.decorators = [PageWrapper];
 TitleTextCardStory.storyName = "TitleTextCard";

--- a/src/stories/molecule/title-text-link-card.stories.tsx
+++ b/src/stories/molecule/title-text-link-card.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+import _ from "@/i18n/locale";
+
 import TitleTextLinkCard from "@/atomic/molecule/title-text-link-card";
-import _, { Locale } from "@/i18n/locale";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Molecule",
@@ -30,4 +32,5 @@ export const TitleTextLinkCardStory: Story = () => (
     </div>
 );
 
+TitleTextLinkCardStory.decorators = [PageWrapper];
 TitleTextLinkCardStory.storyName = "TitleTextLinkCard";

--- a/src/stories/organism/call-to-action.stories.tsx
+++ b/src/stories/organism/call-to-action.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import CallToAction from "@/atomic/organism/call-to-action";
 import _ from "@/i18n/locale";
+
+import CallToAction from "@/atomic/organism/call-to-action";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Organism",
@@ -20,4 +22,5 @@ export const CallToActionStory: Story = () => (
     </section>
 );
 
+CallToActionStory.decorators = [PageWrapper];
 CallToActionStory.storyName = "CallToAction";

--- a/src/stories/organism/header.stories.tsx
+++ b/src/stories/organism/header.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import Header from "@/atomic/organism/header";
 import _ from "@/i18n/locale";
+
+import Header from "@/atomic/organism/header";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Organism",
@@ -30,4 +32,5 @@ export const HeaderStory: Story = () => {
     );
 };
 
+HeaderStory.decorators = [PageWrapper];
 HeaderStory.storyName = "Header";

--- a/src/stories/organism/icon-title-text-list.stories.tsx
+++ b/src/stories/organism/icon-title-text-list.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
-import IconTitleTextList from "@/atomic/organism/icon-title-text-list";
 import _ from "@/i18n/locale";
+
+import IconTitleTextList from "@/atomic/organism/icon-title-text-list";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Organism",
@@ -68,4 +70,5 @@ export const IconTitleTextListStory: Story = () => (
     </section>
 );
 
+IconTitleTextListStory.decorators = [PageWrapper];
 IconTitleTextListStory.storyName = "IconTitleTextList";

--- a/src/stories/organism/navbar.stories.tsx
+++ b/src/stories/organism/navbar.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
+
 import NavigationBar from "@/atomic/organism/navbar";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Organism",
@@ -14,4 +16,5 @@ export const NavigationBarStory: Story = () => {
     );
 };
 
+NavigationBarStory.decorators = [PageWrapper];
 NavigationBarStory.storyName = "Navigation Bar";

--- a/src/stories/organism/review-card-slider.stories.tsx
+++ b/src/stories/organism/review-card-slider.stories.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 import _ from "@/i18n/locale";
 import appIds from "@/data/app-ids.json";
+
 import { ReviewContext } from "@/atomic/molecule/review-context";
 import ReviewCardSlider from "@/atomic/organism/review-card-slider";
 import { useMediaQuery, useReviewData } from "@/hooks";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Organism",
@@ -61,4 +63,5 @@ export const ReviewCardSliderStory: Story = () => {
     );
 };
 
+ReviewCardSliderStory.decorators = [PageWrapper];
 ReviewCardSliderStory.storyName = "ReviewCardSlider";

--- a/src/stories/organism/social-bar.stories.tsx
+++ b/src/stories/organism/social-bar.stories.tsx
@@ -3,6 +3,7 @@ import type { Story, StoryDefault } from "@ladle/react";
 import _ from "@/i18n/locale";
 
 import SocialBar from "@/atomic/organism/social-bar";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Organism",
@@ -17,4 +18,5 @@ export const SocialBarStory: Story = () => (
     </div>
 );
 
+SocialBarStory.decorators = [PageWrapper];
 SocialBarStory.storyName = "SocialBar";

--- a/src/stories/prototype/review.stories.tsx
+++ b/src/stories/prototype/review.stories.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import type { Story, StoryDefault } from "@ladle/react";
 import appIds from "@/data/app-ids.json";
+import _, { Locale } from "@/i18n/locale";
 
 import Review from "@/atomic/prototype/review";
-import _, { Locale } from "@/i18n/locale";
+import { PageWrapper } from ".ladle/decorators";
 
 export default {
     title: "Prototype",
@@ -28,4 +29,5 @@ export const ReviewStory: Story = () => (
     />
 );
 
+ReviewStory.decorators = [PageWrapper];
 ReviewStory.storyName = "Review";


### PR DESCRIPTION
Добавлен декоратор PageWrapper во все Ladle stories. Также проведен небольшой рефакторинг импортов в сторис (добавлены пустые строки для разделения импортов по категориям).