### PR TITLE
Ms 1249 correcting defects

### DIFF
--- a/src/atomic/molecule/text-link-arrow.tsx
+++ b/src/atomic/molecule/text-link-arrow.tsx
@@ -3,6 +3,8 @@ import "@/sass/molecule/text-link-arrow.scss";
 
 interface CSSPropertiesWithVars extends CSSProperties {
     "--hover-color"?: CSSProperties["color"];
+    "--font-family"?: CSSProperties["fontFamily"];
+    "--font-size"?: CSSProperties["fontSize"];
 }
 
 export interface TextLinkArrowProps {
@@ -12,7 +14,9 @@ export interface TextLinkArrowProps {
     isNewTab?: boolean;
     color?: CSSProperties["color"];
     hoverColor?: CSSProperties["color"];
-    hasUnderlineHover?: boolean; 
+    fontFamily?: CSSProperties["fontFamily"];
+    fontSize?: CSSProperties["fontSize"]; // Новый пропс
+    hasUnderlineHover?: boolean;
 }
 
 export default function TextLinkArrow({
@@ -22,7 +26,9 @@ export default function TextLinkArrow({
     isNewTab,
     color = "#0d6efd",
     hoverColor = "#0a58ca",
-    hasUnderlineHover = true, 
+    fontFamily = "",
+    fontSize = "1.2rem", // Значение по умолчанию
+    hasUnderlineHover = true,
 }: TextLinkArrowProps) {
     const newTabProps = isNewTab && { target: "_blank", rel: "noreferrer noopener" };
 
@@ -31,7 +37,14 @@ export default function TextLinkArrow({
             href={href}
             {...newTabProps}
             className={`text-link-arrow d-flex align-items-center gap-2 text-decoration-none lh-sm ${hasUnderlineHover ? "with-underline" : ""}`}
-            style={{ color, "--hover-color": hoverColor } as CSSPropertiesWithVars}
+            style={{
+                color,
+                "--hover-color": hoverColor,
+                fontFamily,
+                "--font-family": fontFamily,
+                fontSize,
+                "--font-size": fontSize,
+            } as CSSPropertiesWithVars}
         >
             {text}
             {rightIcon}

--- a/src/atomic/molecule/text-link-arrow.tsx
+++ b/src/atomic/molecule/text-link-arrow.tsx
@@ -44,6 +44,8 @@ export default function TextLinkArrow({
                 "--font-family": fontFamily,
                 fontSize,
                 "--font-size": fontSize,
+                position: "relative",
+                zIndex: "10"
             } as CSSPropertiesWithVars}
         >
             {text}

--- a/src/atomic/molecule/title-text-link-card.tsx
+++ b/src/atomic/molecule/title-text-link-card.tsx
@@ -17,7 +17,9 @@ interface Props {
     borderClass?: string; 
     imageZIndex?: number; 
     imageOpacity?: number; 
-    additionalCardClass?: string
+    additionalCardClass?: string;
+    fontFamily?: string;
+    fontSize?: string
 }
 
 interface Link {
@@ -35,12 +37,14 @@ const TitleTextLinkCard: React.FC<Props> = ({
     alt = "Image",
     arrowImage = null,
     hoverColor = "",
-    color="",
+    color = "",
     hasShadow = false,
     borderClass = "",
     imageZIndex = 1, 
     imageOpacity = 1,
-    additionalCardClass = ""
+    additionalCardClass = "",
+    fontFamily = "",
+    fontSize = ""
 }) => {
     return (
         <div className={gridColumnClass}>
@@ -54,7 +58,7 @@ const TitleTextLinkCard: React.FC<Props> = ({
                     />
                 )}
                 <div>
-                    <h3>{title}</h3>
+                    <h3 style={{zIndex: 2}}>{title}</h3>
                     <p>{text}</p>
                     <TextLinkArrow
                         href={link.href}
@@ -63,6 +67,8 @@ const TitleTextLinkCard: React.FC<Props> = ({
                         isNewTab={true}
                         color={color}
                         hoverColor={hoverColor}
+                        fontFamily={fontFamily}
+                        fontSize={fontSize}
                     />
                 </div>
             </div>

--- a/src/atomic/molecule/title-text-link-card.tsx
+++ b/src/atomic/molecule/title-text-link-card.tsx
@@ -58,8 +58,8 @@ const TitleTextLinkCard: React.FC<Props> = ({
                     />
                 )}
                 <div>
-                    <h3 style={{zIndex: 2}}>{title}</h3>
-                    <p>{text}</p>
+                    <h3 style={{zIndex: 10, position: "relative"}}>{title}</h3>
+                    <p style={{zIndex: 10, position: "relative"}}>{text}</p>
                     <TextLinkArrow
                         href={link.href}
                         rightIcon={arrowImage}

--- a/src/atomic/page/careers.tsx
+++ b/src/atomic/page/careers.tsx
@@ -137,10 +137,12 @@ const Careers = () => {
                                 image={image}
                                 imageOpacity={0.3}
                                 alt={getAlt()}
-                                arrowImage={<img src="/img/arrow-right.svg" width={6} height={12} />}
+                                arrowImage={<img src="/img/arrow-right.svg" width={7} height="auto"/>}
                                 color="#0d6efd"
                                 hoverColor="#0a58ca"
                                 imageZIndex={0}
+                                fontFamily="os6"
+                                fontSize="1rem"
                             />
                         ))}
                     </div>


### PR DESCRIPTION
Это исправления к задаче 1249 https://martspec.atlassian.net/jira/software/c/projects/MS/boards/1?selectedIssue=MS-1249

Там есть связанные задачи 1365, 1366, 1367.

В этом коммите исправлена только 1365 -  в компоненты TextLinkArrow и Title-Text-Link-Card добавлены пропсы fontSize, fontFamily, чтобы ссылка больше соответствовала макету из фигмы

Также был баг с тем, что ссылки на страницу vacancy-details не работали, так как фоновое изображение находилось поверх них.
(Это произошло, когда мы делали компонент карты переиспользуемым и для Карьеры, и для Электролита (там карточки используются в секции минералов). И разные настройки z-index не подходили к обеим страницам.)
Сейчас этот баг 1299 уже закрыт https://martspec.atlassian.net/jira/software/c/projects/MS/issues/MS-1299?jql=project%20%3D%20%22MS%22%20AND%20type%20%3D%20Bug%20ORDER%20BY%20created%20DESC

Но на странице вроде бы нет никаких изменений.
Поэтому в этом коммите еще добавлены z-index к титлу, ссылке и тексту. Сейчас они находятся поверх изображения, все должно работать.

Я посмотрела, где еще используются text-link-arrow и title-text-link-card, вроде бы эти изменения ни на что не повлияли, на остальные части сайта.

- Баг 1366 https://martspec.atlassian.net/browse/MS-1366

Там как будто бы не критично, наверное, его можно закрыть. Там есть комментарии о медиа-запросах.

- Баг 1367 https://martspec.atlassian.net/browse/MS-1367
Его еще не смотрела, он вроде бы тоже не критичный, там несоответствие стилям из фигмы.
Наверное, его можно было бы доделать в этой ветке