### PR TITLE
Ms 1349 correction link for responding to a vacancy

### DIFF
--- a/src/atomic/prototype/vacancy-details.tsx
+++ b/src/atomic/prototype/vacancy-details.tsx
@@ -130,7 +130,7 @@ const VacancyDetails: React.FC<VacancyDetailsProps> = ({ position }) => {
                             </section>
 
                             <section className='row'>
-                                <a href={vacancyData.APPLY_LINK} target="_blank" rel="noopener noreferrer">
+                                <a className="d-inline-block w-auto" href={vacancyData.APPLY_LINK} target="_blank" rel="noopener noreferrer">
                                     <button className='mt-2 ms-btn-large mb-6'>{data.RESPONSE_BTN}</button>
                                 </a>
                             </section>

--- a/src/atomic/prototype/vacancy-details.tsx
+++ b/src/atomic/prototype/vacancy-details.tsx
@@ -129,10 +129,13 @@ const VacancyDetails: React.FC<VacancyDetailsProps> = ({ position }) => {
                                 </ul>
                             </section>
 
-                            <section className='row'>
-                                <a className="d-inline-block w-auto" href={vacancyData.APPLY_LINK} target="_blank" rel="noopener noreferrer">
-                                    <button className='mt-2 ms-btn-large mb-6'>{data.RESPONSE_BTN}</button>
-                                </a>
+                            <section className="row">
+                                <button 
+                                    className="mt-2 ms-btn-large mb-6 w-auto" 
+                                    onClick={() => window.open(vacancyData.APPLY_LINK, '_blank', 'noopener,noreferrer')}
+                                >
+                                    {data.RESPONSE_BTN}
+                                </button>
                             </section>
                         </>
                     )}


### PR DESCRIPTION
Bug https://martspec.atlassian.net/jira/software/c/projects/MS/boards/1?assignee=712020%3Ae0b156fe-c3ae-4471-bf53-7568ab7366f9&selectedIssue=MS-1349

the button was wrapped in a link so there was clickable space around it. this was partially fixed by adding d-inline-block w-auto classes to the link, but there was still a small clickable space at the bottom, under the button

removed the link and left only the button