### PR TITLE
[MS-1350] fix: fixed Footer links and changed some associated styles

### DIFF
--- a/src/atomic/organism/footer.tsx
+++ b/src/atomic/organism/footer.tsx
@@ -10,58 +10,82 @@ export const Footer = () => (
                 <div className="row">
                     <div className="col-md-4 col-7 d-flex flex-column">
                         <h2 className="mb-4"> {_("NAV.ABOUT").toUpperCase()} </h2>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("about")}>
-                            {" "}
-                            {_("ABOUT.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("mission")}>
-                            {" "}
-                            {_("MISSION.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("team")}>
-                            {" "}
-                            {_("TEAM.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("careers")}>
-                            {" "}
-                            {_("CAREERS.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link" href={Locale.i18nLink("privacy-policy")}>
-                            {" "}
-                            {_("PP.HEAD")}{" "}
-                        </a>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("about")}>
+                                {" "}
+                                {_("ABOUT.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("mission")}>
+                                {" "}
+                                {_("MISSION.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("team")}>
+                                {" "}
+                                {_("TEAM.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("careers")}>
+                                {" "}
+                                {_("CAREERS.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link">
+                            <a href={Locale.i18nLink("privacy-policy")}>
+                                {" "}
+                                {_("PP.HEAD")}{" "}
+                            </a>
+                        </div>
                     </div>
 
                     <div className="col-md-4 col-5 d-flex flex-column">
                         <h2 className="mb-4"> {_("NAV.APPS").toUpperCase()} </h2>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("vitamin")}>
-                            {" "}
-                            {_("VITAMIN.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("bodysize")}>
-                            {" "}
-                            {_("SIZE.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("bodymass")}>
-                            {" "}
-                            {_("MASS.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("waistline")}>
-                            {" "}
-                            {_("WAIST.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("bodyzinc")}>
-                            {" "}
-                            {_("ZINC.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("emotion")}>
-                            {" "}
-                            {_("EMOTION.HEAD")}{" "}
-                        </a>
-                        <a className="footer-link mb-1" href={Locale.i18nLink("electrolyte")}>
-                            {" "}
-                            {_("ELECTROLYTE.HEAD")}{" "}
-                        </a>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("vitamin")}>
+                                {" "}
+                                {_("VITAMIN.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("bodysize")}>
+                                {" "}
+                                {_("SIZE.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("bodymass")}>
+                                {" "}
+                                {_("MASS.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("waistline")}>
+                                {" "}
+                                {_("WAIST.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("bodyzinc")}>
+                                {" "}
+                                {_("ZINC.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("emotion")}>
+                                {" "}
+                                {_("EMOTION.HEAD")}{" "}
+                            </a>
+                        </div>
+                        <div className="footer-link mb-1">
+                            <a href={Locale.i18nLink("electrolyte")}>
+                                {" "}
+                                {_("ELECTROLYTE.HEAD")}{" "}   
+                            </a>
+                        </div>
                     </div>
 
                     <div className="col-md-4 col-12 d-flex flex-md-column flex-row-reverse px-0 icon-container">

--- a/src/sass/organism/footer.scss
+++ b/src/sass/organism/footer.scss
@@ -18,13 +18,6 @@ footer {
     .footer-link {
         font-size: 1.5rem;
         font-family: os3;
-        color: white;
-
-        &:hover {
-            cursor: pointer;
-            color: #79b6f2;
-            text-decoration: underline;
-        }
 
         @include media-breakpoint-down(sm) {
             font-size: 1.2rem;
@@ -38,8 +31,10 @@ footer {
     }
 
     a {
+        cursor: pointer;
         text-decoration: none;
-        color: #aaa;
+        color: rgba(255, 255, 255, 0.7);
+        transition: color 0.3s ease;
 
         &:hover {
             color: #fafafa;


### PR DESCRIPTION
Исправлена ошибка, при которой ссылки в Footer были кликабельны за пределами текста. А также были изменены стили этих ссылок , чтобы Footer больше соответствовал макету (изменен цвет ссылок и добавлена плавность изменения цвета при наведении).
### Предыдущий вариант ссылок в Footer:
![chrome_hRnqwktru6](https://github.com/user-attachments/assets/a81c4251-8af5-4a23-be28-9d80a6b8b151)
### Исправленный вариант:
![chrome_QIaMXB2OUU](https://github.com/user-attachments/assets/36e7632b-6258-428f-a429-bc4c991017f8)
### Макет:
![image](https://github.com/user-attachments/assets/04c97105-8d45-4cc7-b5d4-c713e5347652)
