### PR TITLE
[MS-1358] fix: fixed resize of the Review section

### DIFF
--- a/src/atomic/prototype/review.tsx
+++ b/src/atomic/prototype/review.tsx
@@ -20,7 +20,7 @@ interface IReview {
     appId: number;
 }
 
-const LG_BOOTSTRAP = 992;
+const LG_BOOTSTRAP = 991;
 const XXL_BOOTSTRAP = 1400;
 
 export default function Review({ text, appId, codes }: IReview) {


### PR DESCRIPTION
Исправлено изменение размера раздела отзывов с ПК версии на мобильную с ширины 992px на ширину 991px:
![image](https://github.com/user-attachments/assets/cc0261fa-9307-47bd-b6a3-46e62de89275)
![image](https://github.com/user-attachments/assets/1de29ae3-588d-41f3-96d7-d2b5379b4f80)
