### PR TITLE
[MS-1387] CallToAction component upgrade

### DIFF
--- a/src/atomic/organism/call-to-action-new.tsx
+++ b/src/atomic/organism/call-to-action-new.tsx
@@ -1,0 +1,63 @@
+import React, { CSSProperties, ReactNode } from "react";
+import _, { Locale } from "@/i18n/locale";
+import ButtonApple from "@/atomic/atom/button-apple";
+import ImageI18N from "@/atomic/atom/img-i18n";
+
+type CallToActionProps = {
+    title: string;
+    subtitle: string;
+    textList?: string;
+    appId: number;
+    appDownloadTitle: string;
+    button?: ReactNode;
+    bgColor?: CSSProperties;
+    imgPosition?: "left" | "right";
+};
+
+type WithImage<Props> = Props & {
+    imgSrc: string;
+    imgAlt: string;
+};
+
+type WithoutImage<Props> = Props & {
+    imgSrc: never;
+    imgH?: never;
+    imgW?: never;
+    imgAlt: never;
+};
+interface ImageI18NModel {
+    src: string; // image url. Should have postfix with .en. EX: /img/vitamin.en.512.webp
+    alt?: string; // alt text to show when image fails to load
+    cls?: string; // classNames to apply from css
+    h: number; // element height
+    w: number; // element width
+}
+export default function CallToAction(props: WithImage<CallToActionProps> | WithoutImage<CallToActionProps>) {
+    const { title, subtitle, textList, button, bgColor, imgSrc, imgAlt, appId, appDownloadTitle, imgPosition = "right" } = props;
+    const marginBot = { marginBottom: "3rem" };
+
+    return (
+        <div className="row text-lg-start text-center page-bottom">
+            <div className="col-12 block bg-blue" style={bgColor}>
+                {imgPosition === "left" && (
+                    <ImageI18N src={imgSrc} h={400} w={400} cls="ms-base-image ms-lg-auto" alt={imgAlt} />
+                )}
+
+                <div>
+                    <h2>{_(title)}</h2>
+                    {
+                        <p className="flex-grow-1" style={marginBot}>
+                            {_(subtitle)}
+                        </p>
+                    }
+                    {button}
+                    {textList}
+                </div>
+
+                {imgPosition === "right" && (
+                    <ImageI18N src={imgSrc} h={400} w={400} cls="ms-base-image ms-lg-auto me-lg-0" alt={imgAlt} />
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/atomic/organism/call-to-action-new.tsx
+++ b/src/atomic/organism/call-to-action-new.tsx
@@ -22,13 +22,7 @@ type WithoutImage<Props> = Props & {
     imgW?: never;
     imgAlt: never;
 };
-interface ImageI18NModel {
-    src: string; // image url. Should have postfix with .en. EX: /img/vitamin.en.512.webp
-    alt?: string; // alt text to show when image fails to load
-    cls?: string; // classNames to apply from css
-    h: number; // element height
-    w: number; // element width
-}
+
 export default function CallToAction(props: WithImage<CallToActionProps> | WithoutImage<CallToActionProps>) {
     const { title, subtitle, textList, button, bgColor, imgSrc, imgAlt, imgPosition = "right" } = props;
     const marginBot = { marginBottom: "3rem" };

--- a/src/atomic/organism/call-to-action-new.tsx
+++ b/src/atomic/organism/call-to-action-new.tsx
@@ -1,17 +1,14 @@
 import React, { CSSProperties, ReactNode } from "react";
-import _, { Locale } from "@/i18n/locale";
-import ButtonApple from "@/atomic/atom/button-apple";
+import _ from "@/i18n/locale";
 import ImageI18N from "@/atomic/atom/img-i18n";
 
 type CallToActionProps = {
     title: string;
-    subtitle: string;
-    textList?: string;
-    appId: number;
-    appDownloadTitle: string;
+    subtitle?: string;
+    textList?: string[];
     button?: ReactNode;
-    bgColor?: CSSProperties;
     imgPosition?: "left" | "right";
+    bgColor?: CSSProperties;
 };
 
 type WithImage<Props> = Props & {
@@ -33,7 +30,7 @@ interface ImageI18NModel {
     w: number; // element width
 }
 export default function CallToAction(props: WithImage<CallToActionProps> | WithoutImage<CallToActionProps>) {
-    const { title, subtitle, textList, button, bgColor, imgSrc, imgAlt, appId, appDownloadTitle, imgPosition = "right" } = props;
+    const { title, subtitle, textList, button, bgColor, imgSrc, imgAlt, imgPosition = "right" } = props;
     const marginBot = { marginBottom: "3rem" };
 
     return (
@@ -45,14 +42,22 @@ export default function CallToAction(props: WithImage<CallToActionProps> | Witho
 
                 <div>
                     <h2>{_(title)}</h2>
-                    {
+                    {subtitle && (
                         <p className="flex-grow-1" style={marginBot}>
                             {_(subtitle)}
                         </p>
-                    }
+                    )}
+                    {/* TODO: создать компонент для отображения textList c возможностью передачи цвета буллет-поинтов, локализацией и улучшенной стилизацией */}
+                    {textList && (
+                        <ul style={{ listStyleType: "disc", paddingLeft: "1rem" }}>
+                            {textList.map((item, index) => (
+                                <li key={index}>{_(item)}</li>
+                            ))}
+                        </ul>
+                    )}
                     {button}
-                    {textList}
                 </div>
+
 
                 {imgPosition === "right" && (
                     <ImageI18N src={imgSrc} h={400} w={400} cls="ms-base-image ms-lg-auto me-lg-0" alt={imgAlt} />

--- a/src/atomic/organism/call-to-action-new.tsx
+++ b/src/atomic/organism/call-to-action-new.tsx
@@ -58,7 +58,6 @@ export default function CallToAction(props: WithImage<CallToActionProps> | Witho
                     {button}
                 </div>
 
-
                 {imgPosition === "right" && (
                     <ImageI18N src={imgSrc} h={400} w={400} cls="ms-base-image ms-lg-auto me-lg-0" alt={imgAlt} />
                 )}

--- a/src/stories/organism/call-to-action-new.stories.tsx
+++ b/src/stories/organism/call-to-action-new.stories.tsx
@@ -20,7 +20,7 @@ export const CallToActionStory: Story = () => (
 //            textList={[_("VITAMIN.ABOUT_1"), _("VITAMIN.ABOUT_2"), _("VITAMIN.ABOUT_3")]}
             imgSrc="/img/org/call-to-action/vitamin/vitamin-screen-app-en.webp"
             imgAlt={_("VITAMIN.ALT3")}
-            imgPosition="right"
+//            imgPosition="right"
         />
     </section>
 );

--- a/src/stories/organism/call-to-action-new.stories.tsx
+++ b/src/stories/organism/call-to-action-new.stories.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { Story, StoryDefault } from "@ladle/react";
+import _ from "@/i18n/locale";
+import ButtonApple from "@/atomic/atom/button-apple";
+import appIds from "@/data/app-ids.json";
+
+import CallToAction from "@/atomic/organism/call-to-action-new";
+import { PageWrapper } from ".ladle/decorators";
+
+export default {
+    title: "Organism",
+} satisfies StoryDefault;
+
+export const CallToActionStory: Story = () => (
+    <section>
+        <CallToAction
+            title={_("VITAMIN.HEAD6")}
+            subtitle={_("VITAMIN.DESC6")}
+            button={<ButtonApple appId={appIds["vitamin"]} appDownloadTitle={"Vitamin"} />}
+            textList={""}
+            appId={2}
+            appDownloadTitle={_("VITAMIN.DWN")}
+            imgSrc="/img/org/call-to-action/vitamin/vitamin-screen-app-en.webp"
+            imgAlt={_("VITAMIN.ALT3")}
+        />
+    </section>
+);
+
+CallToActionStory.decorators = [PageWrapper];
+CallToActionStory.storyName = "CallToActionNew";

--- a/src/stories/organism/call-to-action-new.stories.tsx
+++ b/src/stories/organism/call-to-action-new.stories.tsx
@@ -16,12 +16,11 @@ export const CallToActionStory: Story = () => (
         <CallToAction
             title={_("VITAMIN.HEAD6")}
             subtitle={_("VITAMIN.DESC6")}
-            button={<ButtonApple appId={appIds["vitamin"]} appDownloadTitle={"Vitamin"} />}
-            textList={""}
-            appId={2}
-            appDownloadTitle={_("VITAMIN.DWN")}
+            button={<ButtonApple appId={appIds["vitamin"]} appDownloadTitle={_("VITAMIN.DWN")} />}
+//            textList={[_("VITAMIN.ABOUT_1"), _("VITAMIN.ABOUT_2"), _("VITAMIN.ABOUT_3")]}
             imgSrc="/img/org/call-to-action/vitamin/vitamin-screen-app-en.webp"
             imgAlt={_("VITAMIN.ALT3")}
+            imgPosition="right"
         />
     </section>
 );


### PR DESCRIPTION
Обновлен компонент CallToAction, пока сделан отдельный компонент call-to-action-new (и соответствующая сторис в ладли), чтобы его изолированно отработать перед внедрением в проект.

Изменения следующее:
1. Теперь кнопка передается отдельным пропсом как ReactNode.
2. Добавлен пропс textList (в некоторых кейсах с макетов может быть необходим). 
3. Пока textList сделан внутри верстки, но на будущее предлагаю сделать его отдельным компонентом (можно назвать BulletList, похожих компонентов я не нашел). Списки с буллет-поинтами повторяются довольно часто, сами буллет-поинты могут различаться по цвету. Цвет как раз было бы удобно передавать как пропс, плюс в рамках отдельного компонента удобнее настроить стили.
4. Добавлен пропс imgPosition (значения “left”/“right”, позволяет менять местами текст и картинку). Использован условный рендеринг для улучшения читаемости кода (реализация через свойство order хуже воспринимается).
5. Почти все пропсы в компоненте теперь опциональные, что позволяет их свободно включать/выключать. 