### PR TITLE
[MS-1372] fix: delete "btn" class to remove extra border in active state

### DIFF
--- a/src/atomic/atom/button-chevron-right.tsx
+++ b/src/atomic/atom/button-chevron-right.tsx
@@ -9,7 +9,7 @@ interface ButtonChevronRight {
 
 const ButtonChevronRight: React.FC<ButtonChevronRight> = ({ text, link, className = "" }) => {
     return (
-        <a href={link} target="_blank" rel="noopener noreferrer" className={`btn btn-chevron-right ${className}`}>
+        <a href={link} target="_blank" rel="noopener noreferrer" className={`btn-chevron-right ${className}`}>
             <div id="container">
                 <button className="learn-more">
                     <div className="circle">


### PR DESCRIPTION
Исправлена ошибка, из-за которой при нажатии на кнопку "Узнать больше" вокруг появлялась лишняя граница. 

<img width="323" alt="Screenshot 2025-03-22 at 19 08 50" src="https://github.com/user-attachments/assets/c577258f-6ea3-4fcc-8644-82131f6140dd" />
