### PR TITLE
[MS-1431] fix: remove visual step on Waist and Weight pages

### DIFF
--- a/src/atomic/page/mass.tsx
+++ b/src/atomic/page/mass.tsx
@@ -135,8 +135,8 @@ export default function Bodymass() {
                         <div className="col-12 col-xxl-6">
                             <ImageI18N
                                 src="/img/page/body-mass/why-mass-en.webp"
-                                w={487}
-                                h={515}
+                                w={620}
+                                h={390}
                                 cls="ms-base-image mt-mob-xs"
                             />
                         </div>

--- a/src/atomic/page/waist.tsx
+++ b/src/atomic/page/waist.tsx
@@ -115,7 +115,7 @@ export default function WaistLine() {
                     </div>
                 </section>
 
-                <div className="ms-base-page ms-base-new waist call-to-action why-waist-section">
+                <div className="ms-base-page ms-base-new row waist call-to-action why-waist-section">
                     <CallToAction
                         title={_("WAIST.HEAD1")}
                         subtitle={_("WAIST.DESC1")}


### PR DESCRIPTION
Исправлена ступенька между секциями на страницах Талия и Вес.
![image](https://github.com/user-attachments/assets/1844af14-2fbb-43ac-8baa-2022fa5664e6)
![image](https://github.com/user-attachments/assets/c042605b-c95c-4ed5-bb1a-0878b3b838bf)
