### PR TITLE
[MS-1432] fix: adjusted spacing and removed shadows from filled cards on Waist page

### DIFF
--- a/src/sass/molecule/card-icon-title-text.scss
+++ b/src/sass/molecule/card-icon-title-text.scss
@@ -23,6 +23,7 @@
     }
 
     &.has-bg-color {
+        box-shadow: none;
         .icon {
             background-color: white;
         }

--- a/src/sass/page/waist.scss
+++ b/src/sass/page/waist.scss
@@ -122,11 +122,13 @@
   .waist-info-section {
     h2 {
         font-size: 3.08rem;
+        margin-bottom: 1.9rem;
     }
     p {
         font-size: 1.39rem;
         line-height: 120%;
         max-width: 800px;
+        margin-bottom: 5rem;
     }
     .info-list {
         padding: 0;


### PR DESCRIPTION
Исправлены отступы между блоками на странице Талия согласно макету в Figma  и убраны тени у залитых карточек.

![image](https://github.com/user-attachments/assets/64fcc102-1111-40e8-9162-5e9216855942)
