### PR TITLE
MS-1441-portuguese-and-german-translation-issue-untranslated-card-zinc

### DIFF
--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -974,6 +974,7 @@
         "SUBHEAD": "rastreamento ingestão zinco",
         "ICO": "Ícone do nosso aplicativo Apple Watch gratuito que ajuda você a monitorar o consumo de zinco. Faça registros sobre o zinco na dieta de seus Apple Watches e sincronize com o app Saúde da Apple. Não é necessário um aplicativo complementar para iPhone para funcionar. Zero anúncios.",
         "TEXT": "Bonito em sua simplicidade rastreador de zinco no corpo para o seu relógio. app Saúde da Apple ativado. Resultados reais. Livre. Zero anúncios.",
+        "TEXT1": "Um rastreador de níveis de zinco para o seu corpo, desenvolvido para Apple Watch. Sincroniza com o Apple Health. Entrada de dados fácil. Funciona gratuitamente e sem anúncios.",
         "BTN": "Descubra bem-estar",
         "IMG": "Acompanhe seu consumo diário de suplemento de zinco",
         "DWN": "Obtenha gratuitamente o aplicativo BodyZinc da Apple Store",


### PR DESCRIPTION
I added the missing TEXT1 entry to the translation file (src/i18n/pt.json). Previously, this entry was not present in the file, which resulted in the translation not appearing on the website. With this update, the translation should now be correctly displayed.
Let me know if you need any adjustments!
