### PR TITLE
[1443] Fix: capitalize nouns in German description

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -912,7 +912,7 @@
     },
     "WAIST": {
         "HEAD": "Taille",
-        "SUBHEAD": "winzige Taille - gesundes Herz",
+        "SUBHEAD": "Winzige Taille - Gesundes Herz",
         "ICO": "Symbol für die beste Apple Watch-App zur Verfolgung des Taillenumfangs. Vollständige Synchronisierung mit die Health App. Einfache Nutzung ohne Anzeigen, Zahlungen und Registrierung.",
         "TEXT": "Der einfachste Weg, um den Taillenumfang auf der Apple Watch zu verfolgen. Alle Datensätze werden mit Ihrer die Health App synchronisiert.",
         "IMG": "Behalten Sie Ihre Taillengröße (Bauchnabel) direkt von Ihrem Arm aus im Auge",


### PR DESCRIPTION
## What was done
- Capitalized German nouns in description text as per language rules:
  - `winzige Taille - gesundes Herz` → `Winzige Taille – Gesundes Herz`

## Jira task
[MS-1443] Capitalize nouns in description


[MS-1443]: https://martspec.atlassian.net/browse/MS-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ