### PR TITLE
[MS-1427] fix: made Waist and Weight pages responsive

### DIFF
--- a/src/atomic/page/mass.tsx
+++ b/src/atomic/page/mass.tsx
@@ -88,7 +88,7 @@ export default function Bodymass() {
                 />
 
                 <section>
-                    <div className="row row-cols-xl-3 row-cols-md-2 row-cols-1 g-4">
+                    <div className="row row-cols-xl-3 row-cols-md-3 row-cols-1 g-4">
                         <div className="col">
                             <CardTitleTextImage
                                 title={_("MASS.LIST1.LI1_HEAD")}
@@ -117,7 +117,7 @@ export default function Bodymass() {
                                 </div>
                             </div>
                         </div>
-                        <div className="col col-md-12">
+                        <div className="col col-md-4">
                             <CardImage
                                 imgSrc="/img/page/body-mass/mid-pic-girl-and-apple.png"
                                 imgH={720}

--- a/src/atomic/page/waist.tsx
+++ b/src/atomic/page/waist.tsx
@@ -74,7 +74,7 @@ export default function WaistLine() {
                 />
 
                 <section>
-                    <div className="row row-cols-xl-3 row-cols-md-2 row-cols-1 g-4">
+                    <div className="row row-cols-xl-3 row-cols-md-3 row-cols-1 g-4">
                         <div className="col no-mx-5">
                             <CardTitleTextImage
                                 title={_("WAIST.LIST1.LI1_HEAD")}
@@ -103,7 +103,7 @@ export default function WaistLine() {
                                 </div>
                             </div>
                         </div>
-                        <div className="col col-md-12">
+                        <div className="col col-md-4">
                             <CardImage
                                 imgSrc="/img/page/waistline/middle-section-pic-statistics.png"
                                 imgH={720}


### PR DESCRIPTION
Добавлена адаптивность для мобильных устройств на страницы Талия и Вес:
Теперь переход со строки на колонки в некоторых секциях происходит при ширине экрана менее 768px