### PR TITLE
MS-1611 remove last color

### DIFF
--- a/src/atomic/page/emotion/color-test.tsx
+++ b/src/atomic/page/emotion/color-test.tsx
@@ -385,20 +385,34 @@ export default function ColorTest() {
                         </div>
                         <div className="row g-4">
                             <div className="color-sectors">
-                                {sectorModelCollection.map((sector) => (
-                                    <div key={sector.color}>
-                                        <button
-                                            onClick={() =>
-                                                setUserSelectionCollection((current) => [...current, sector.id])
-                                            }
-                                            className={
-                                                "sector" +
-                                                (userSelectionCollection.includes(sector.id) ? " selected" : "")
-                                            }
-                                            style={{ background: "#" + sector.color }}
-                                        ></button>
-                                    </div>
-                                ))}
+                                {sectorModelCollection
+                                    .filter((sector) => {
+
+                                        const selectedCount = userSelectionCollection.length;
+
+                                        if (
+                                            selectedCount === COLORS.length - 1 &&
+                                            !userSelectionCollection.includes(sector.id)
+                                        ) {
+                                            return false;
+                                        }
+
+                                        return true;
+                                    })
+                                    .map((sector) => (
+                                        <div key={sector.color}>
+                                            <button
+                                                onClick={() =>
+                                                    setUserSelectionCollection((current) => [...current, sector.id])
+                                                }
+                                                className={
+                                                    "sector" +
+                                                    (userSelectionCollection.includes(sector.id) ? " selected" : "")
+                                                }
+                                                style={{ background: "#" + sector.color }}
+                                            ></button>
+                                        </div>
+                                    ))}
                             </div>
                         </div>
                     </section>
@@ -513,7 +527,7 @@ export default function ColorTest() {
             </div>
 
             <Footer />
-            <ScrollButton color="#7B62FE"/>
+            <ScrollButton color="#7B62FE" />
         </>
     );
 }

--- a/src/atomic/page/emotion/color-test.tsx
+++ b/src/atomic/page/emotion/color-test.tsx
@@ -65,7 +65,7 @@ type SectorModelId = number;
 
 const useSelected = ([selectedCollection, setResult]: [
     SectorModel["id"][],
-    React.Dispatch<React.SetStateAction<TestResult>>,
+    React.Dispatch<React.SetStateAction<TestResult | null>>,
 ]) => {
     const sc = selectedCollection;
 
@@ -291,7 +291,7 @@ const useSelected = ([selectedCollection, setResult]: [
     };
 
     React.useLayoutEffect(() => {
-        const scFull = sc.length === COLORS.length;
+        const scFull = sc.length === COLORS.length - 1;
 
         if (!scFull) return;
 


### PR DESCRIPTION
Removal of the last color when selecting the penultimate item

As part of the color test logic update, the behavior of the color cards display has been modified.

Changes:
When the penultimate color card is selected, the last remaining color card is automatically hidden from the interface.
The selection logic and test result calculation remain unchanged.
The behavior of all other cards remains the same.
Purpose:

To make the test flow more linear and prevent a situation where a single unselected card remains, improving the UX and ensuring a smoother completion of the test scenario.