### PR TITLE
[MS-1514] Fix App Store button visibility in dark theme browser

### DIFF
--- a/src/sass/atom/button.scss
+++ b/src/sass/atom/button.scss
@@ -49,6 +49,8 @@
 }
 
 .ms-btn-apple {
+    color-scheme: only light;
+
     img {
         width: 150px;
         height: 50px;


### PR DESCRIPTION
кнопка "Visit on App Store" была невидима в браузере с системной тёмной темой: текст и логотип Apple внутри SVG автоматически инвертировались в светлый, а белый фон оставался белым - содержимое сливалось с фоном

как было: 

<img width="776" height="338" alt="image" src="https://github.com/user-attachments/assets/4451e23e-b91e-4952-b145-678748465a7e" />

причина: SVG-кнопка содержит явные fill="white" (фон) и fill="#212529" (текст/иконка). сайт не декларирует свою цветовую схему, поэтому браузер применяет Auto Dark Mode и инвертируют тёмный текст

фикс: добавлен color-scheme: only light к .ms-btn-apple в src/sass/atom/button.scss. Это говорит браузеру рендерить кнопку строго в светлой схеме и исключает её из автоинверсии. на светлую тему никакого влияния - изменения видны только в dark-mode браузере

стало:

<img width="778" height="392" alt="image" src="https://github.com/user-attachments/assets/53173585-0e0e-4884-8e80-cb23ba28d265" />